### PR TITLE
Fix for mismatched theme color names

### DIFF
--- a/client/src/theme/colors.ts
+++ b/client/src/theme/colors.ts
@@ -7,8 +7,8 @@ export const colors: MantineThemeOverride = {
     emerald: twColors(emerald),
 
     // status colors
-    error: twColors(red),
-    warning: twColors(amber),
+    red: twColors(red),
+    amber: twColors(amber),
   },
   primaryColor: 'emerald',
   white: slate[100],


### PR DESCRIPTION
references...
- #14 
- #7

This fixes an issue with #14 which contained a switch to semantic color names without updating the rest of the codebase. This returns the theme to using literal color names (e.g. `red` for red), which avoids the potential for accidentally using the wrong red without warning.