### PR TITLE
New mantine gray palette

### DIFF
--- a/client/src/app/account/_components/Credentials.tsx
+++ b/client/src/app/account/_components/Credentials.tsx
@@ -24,7 +24,7 @@ export default function Credentials() {
           <div className="flex flex-row items-center justify-between">
             <h3 className="text-lg">Your passkeys</h3>
 
-            <ActionIcon color="black" variant="subtle" onClick={toggle}>
+            <ActionIcon color="slate" variant="subtle" onClick={toggle}>
               {isOpen ? <IconChevronDown /> : <IconPlus />}
             </ActionIcon>
           </div>

--- a/client/src/theme/colors.ts
+++ b/client/src/theme/colors.ts
@@ -10,6 +10,20 @@ export const colors: MantineThemeOverride = {
     // status colors
     red: twColors(red),
     amber: twColors(amber),
+
+    // open-colors gray mixed with tw slate
+    gray: [
+      slate[50],
+      slate[100],
+      '#eaeff5',
+      slate[200],
+      slate[300],
+      '#9babc0',
+      '#73839a',
+      slate[600],
+      slate[700],
+      slate[800],
+    ],
   },
   primaryColor: 'emerald',
   white: slate[100],


### PR DESCRIPTION
- [ ] closes #131 

A new gray palette has been created for Mantine, which is a combination of tailwind hues and open-colors lightness values.

See [color matching breakdown](https://huetone.ardov.me/?palette=N4IgdghgtgpiBcIAqB1ABANwM5oPIGE0AzAewCc0YAHAYxABoQALAVxiwQG1RJYEQSdRjRIAbch3icQAYiIAOIgE4iEBrKIBGIgGYiAVnUyYSmDRhEjAExgwATDABsR81YAsVtYxkQrAI30-KyN5R3kTZ283JX0ABn0AdiMdNx0IN1ijO007fTslI1ii4pAAXQBfeh5oOEQAOQBRFHURcTJJaTlFCCIhDW19ZSMYCAsDYYdFTO8aIP0YTSMlPwg-GmnZBJ15HSUvWTcE-X1HAu8dFM1jo017JR0-QuKissrqvkQAFwB3FrEJLgabq9IxaAxDbz2GBTFxzBZLNwQB7yIyOQ5ueSPKJHE5nWQXNxXQzeW75B6FLQJOz7GSxOyxRyaJIVUqMT4kMDsQFxdSaF6MekbHT8kAZDZxDaOEUJEXyEVKeU8ipAA) on Huetone

