### PR TITLE
2025 head tax numbers

### DIFF
--- a/apps/client/src/data/headTaxData.ts
+++ b/apps/client/src/data/headTaxData.ts
@@ -1,3 +1,4 @@
 // daily head tax for members and guests, in dollars.
-export const DAILY_HEAD_TAX_MEMBERS = 15.0;
-export const DAILY_HEAD_TAX_GUESTS = 20.0;
+export const DAILY_HEAD_TAX_MEMBERS = 18.0;
+export const DAILY_HEAD_TAX_GUESTS = 23.0;
+export const DAILY_HEAD_TAX_CHILDREN = 4.0;


### PR DESCRIPTION
```
EPC Residence Fee Schedule 2025

Day Tripper Family $377
Day tripper individual $189
Teen to Adult $18/night
Children 2-12 $4/night
Children 0-1 Free
Guest’s $23/night
```