### PR TITLE
Fix email modal copy bug

### DIFF
--- a/apps/client/src/app/calendar/_components/EmailsModal.tsx
+++ b/apps/client/src/app/calendar/_components/EmailsModal.tsx
@@ -85,7 +85,7 @@ function EmailsModalForm({
       const text = authorsList
         .map((a, i) => {
           if (!selectedAuthors.get(a.id)) return '';
-          return (!!i ? ',\n' : '') + makeEmailText(a);
+          return (!!i ? '\n' : '') + makeEmailText(a);
         })
         .join('');
       navigator.clipboard.writeText(text);


### PR DESCRIPTION
Calendar "email visitors" modal: fixed bug where a comma was added to the clipboard when the first item was unchecked.